### PR TITLE
Changed the api link to resolve the error

### DIFF
--- a/src/components/ISSMap.jsx
+++ b/src/components/ISSMap.jsx
@@ -46,11 +46,11 @@ const ISSMap = () => {
 
   useEffect(() => {
     const fetchISSPosition = () => {
-      fetch('http://api.open-notify.org/iss-now')
+      fetch('https://api.wheretheiss.at/v1/satellites/25544')
         .then((response) => response.json())
         .then((data) => {
-          const lat = parseFloat(data.iss_position.latitude);
-          const lon = parseFloat(data.iss_position.longitude);
+          const lat = data.latitude;
+          const lon = data.longitude;
           setPosition({ lat, lon });
         })
         .catch((error) => console.error('Error fetching ISS data:', error));


### PR DESCRIPTION
- It seems there was an issue loading 'http://api.open-notify.org/iss-now'. The error message was:

"Mixed Content: The page at 'https://space-discovery-development.netlify.app/' was loaded over HTTPS, but it requested an insecure resource 'http://api.open-notify.org/iss-now'. This request has been blocked because the content must be served over HTTPS."

- To resolve this, the endpoint has been updated to:

"https://api.wheretheiss.at/v1/satellites/25544"